### PR TITLE
Use external Hatanaka library for RINEX decompression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,20 +56,6 @@ Downloads
 .. _x86_32: https://github.com/gnss-lab/tec-suite/releases/download/v0.7.8/tec-suite-v0.7.8-linux32.tgz
 .. _x86_64: https://github.com/gnss-lab/tec-suite/releases/download/v0.7.8/tec-suite-v0.7.8-linux64.tgz
 
-Requirements
-~~~~~~~~~~~~
-
-``crx2rnx``
-    To decompress Hatanaka-compressed RINEX files, **tec-suite** uses
-    `crx2rnx <http://terras.gsi.go.jp/ja/crx2rnx.html>`_.
-
-``gunzip``
-    To unarchive ``.z``, ``.Z`` or ``.gz``, files **tec-suite**
-    uses ``gunzip``. If your system is **Linux** or **macOS** you
-    probably have it installed. You can find the **Windows** version
-    at `GnuWin <http://gnuwin32.sourceforge.net/packages/gzip.htm>`_
-    site.
-
 Usage
 =====
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,26 +12,3 @@ Downloads:
 
 .. _x86_32: https://github.com/gnss-lab/tec-suite/releases/download/v0.7.8/tec-suite-v0.7.8-linux32.tgz
 .. _x86_64: https://github.com/gnss-lab/tec-suite/releases/download/v0.7.8/tec-suite-v0.7.8-linux64.tgz
-
-
-************
-Requirements
-************
-
-``crx2rnx``
-    To decompress Hatanaka-compressed RINEX files, **tec-suite** uses
-    `crx2rnx <http://terras.gsi.go.jp/ja/crx2rnx.html>`_.
-
-``gunzip``
-    To unarchive ``.z``, ``.Z`` or ``.gz``, files **tec-sutie**
-    uses ``gunzip``. If your system is **Linux** or **macOS** you
-    probably have it installed. You can find the **Windows** version
-    at `GnuWin <http://gnuwin32.sourceforge.net/packages/gzip.htm>`_
-    site.
-
-.. note::
-
-   **tec-suite** for Windows comes with ``crx2rnx`` and ``gzip`` executables. In
-   case of Linux or macOS put ``crx2rnx`` to a dir where ``tecs`` could find it,
-   e.g. to the dir which contains ``tecs`` binary or to any dir in ``$PATH``
-   variable.

--- a/rakefile
+++ b/rakefile
@@ -52,12 +52,7 @@ windows? and (
 
   # additional files
   DIST_EXTRA_FILES_PATH = DISTPATH + '/apps'
-  DIST_EXTRA_FILES = [
-    '_distfiles/apps/crx2rnx.exe',
-    '_distfiles/apps/gzip.exe',
-    '_distfiles/apps/crx2rnx.README',
-    '_distfiles/apps/gzip.README'
-  ]
+  DIST_EXTRA_FILES = []
 
   ARCH_CMD = [
     '7z',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     py_modules=["tecs"],
     packages=find_packages(),
 
-    install_requires=['future'],
+    install_requires=['future', 'hatanaka'],
 
     extras_require={
         'test': ['coverage', 'nose'],

--- a/tecs/rinex/__init__.py
+++ b/tecs/rinex/__init__.py
@@ -24,7 +24,7 @@ rinex
 from __future__ import unicode_literals
 
 from tecs.rinex.basic import RinexError
-from tecs.rinex.futils import RE_VER, GZIP, CRX2RNX, expand_obs, expand_nav
+from tecs.rinex.futils import RE_VER, expand_obs, expand_nav
 from tecs.rinex.header import RinexVersionType
 
 from tecs.rinex.v2.o import Obs2, Obs21, Obs211


### PR DESCRIPTION
Hi! I recently created a carefully packaged and wrapped version of the RNXCMP tools in Python as the [Hatanaka](https://github.com/valgur/hatanaka) library. It simplifies the installation and usage of the tools and also makes sure any errors are raised as proper exceptions and warnings as Python warnings. In addition to the Hatanaka decompression it can also take care of the .gz/.Z compression usually applied on top of Hatanaka compression.

I thought you might find the library useful as well. It should make packaging this library quite a bit simpler, I hope. One caveat, though, is that it sets the minimum Python version to 3.6+, but I doubt it's an issue since Python 2 has been EOL-ed for a while now.